### PR TITLE
fix: reduce hero opacity and use verified email domain

### DIFF
--- a/src/components/public/Hero.tsx
+++ b/src/components/public/Hero.tsx
@@ -23,7 +23,7 @@ export function Hero() {
         aria-hidden="true"
       />
       <div
-        className="absolute inset-0 bg-navy/70"
+        className="absolute inset-0 bg-navy/60"
         aria-hidden="true"
       />
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -19,7 +19,7 @@ export async function sendContactNotification(data: ContactFormData): Promise<vo
   }
 
   await getResend().emails.send({
-    from: "Sweis Bookkeeping <onboarding@resend.dev>",
+    from: "Sweis Bookkeeping <noreply@hannasweis.com>",
     to: contactEmail,
     subject: `New Contact Form Submission from ${sanitizeSubject(data.name)}`,
     html: `


### PR DESCRIPTION
## Summary
- Reduced hero dark overlay from 70% to 60% so the background photo is more visible
- Updated contact form email sender from `onboarding@resend.dev` (Resend test address) to `noreply@hannasweis.com` (verified custom domain) so notifications actually reach `hssweis@gmail.com`

## Test plan
- [ ] Verify hero background photo is more visible on landing page
- [ ] Submit a test contact form and confirm email arrives at hssweis@gmail.com (requires Resend domain verification to complete)
- [ ] Confirm admin panel still shows submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)